### PR TITLE
Corrected numpy reference from onp to np (error from JAX code)

### DIFF
--- a/getting_started_pytorch.ipynb
+++ b/getting_started_pytorch.ipynb
@@ -611,7 +611,7 @@
       },
       "source": [
         "with open('neurips_bdl_starter_kit/data/cifar10/probs.csv', 'r') as fp:\n",
-        "  reference = onp.loadtxt(fp)"
+        "  reference = np.loadtxt(fp)"
       ],
       "execution_count": null,
       "outputs": []


### PR DESCRIPTION
Fixed how numpy is called. In this notebook numpy is loaded as np, whereas in the JAX notebook as onp. Maybe a copy paste error was made.

@sharadmv much better right?